### PR TITLE
Issue templates for the Grml repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps To Reproduce**
+Steps to reproduce the behavior:
+```
+ > …
+```
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**In which Grml Version did the bug occur?**
+<!-- Please consider reproducing this bug with a Daily Grml Snapshot: https://grml.org/daily/ -->
+
+Output of `grml-version`:
+```sh
+# grml-version
+...
+```
+
+**Additional context**
+Add any other context about the problem here.
+
+**Additional program output to the terminal or log subsystem illustrating the issue**
+
+<!-- Please paste relevant program terminal or journal output here. For very
+     long copy/pasted data consider using a service like https://paste.grml.org/.
+     Where copy/paste is not possible (for example early boot or late
+     shutdown), a photo of the screen might do too, but text is always much
+     preferred. -->
+
+```text
+…

--- a/.github/ISSUE_TEMPLATE/software-request.md
+++ b/.github/ISSUE_TEMPLATE/software-request.md
@@ -1,0 +1,35 @@
+---
+name: Software / Feature request
+about: Suggest an application or a feature
+
+---
+
+**Is your software / feature request related to a problem? Please describe.**
+A clear and concise description of what the problem can be solved with that requested software. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Disk usage of the software**
+Space on the CD images is limited. Did you try to install it on the latest Daily Grml Snapshot. How much disk space will be used after installation (including all dependencies)?
+
+```shell
+# apt update
+# apt install --assume-no $PACKAGE
+[...]
+After this operation, 10.1 MB of additional disk space will be used.
+
+# apt-cache show $PACKAGE | grep Installed-Size
+Installed-Size: 338
+```
+
+**The Grml version and flavour you checked that didn't have the feature you are asking for**
+<!-- Please check if the package is already included in the latest Daily Grml Snapshot: https://grml.org/daily/ -->
+
+```shell
+# grml-version
+...
+```


### PR DESCRIPTION
With issue templates we can standardize the information we'd like
contributors to include when they open issues in our repository.

We want to help our contributors to provide specific, structured
information when they open issues.

This makes it easier for us to address and fix the issue.

Read more: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates