### PR TITLE
Update release checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -7,84 +7,91 @@ assignees: ''
 
 ---
 
-<!-- 
-This release checklist issue should be created once all decicions in section "Planning" have been made.
+<!--
+Release checklist guide:
 
-The tasks in section "Release Kick-Off" needs to be completed on issue creation.
-
-The tasks in section "Preflight" should be completed after the issue has been created.
-
-The tasks in section "Doing" should be completed on release day.
-
-The tasks in section "Announce" should be completed soon after the release.
+* The tasks in the section "Release Kick-Off" needs to be completed on issue creation.
+* Replace YY and MM in the description (with the values from the "New release")
+* Replase $PROJECTID with the GitHub project ID
+* Remove the comments from the tasks (once they are completed)
+* The tasks in section "Preflight" should be completed after the issue has been created.
+* The tasks in section "Release Day" should be completed on release day.
+* The tasks in section "Announce Release" should be completed soon after the release.
+* The tasks in section "Post Release Day" should be completed after the release.
 
 Terminology (with examples):
 
-Old-Latest release: 2024.12
-Latest release: 2025.05
-New release: 2025.08 (the release we are working on)
-Next release: 2025.Q4
+* Old-Latest release: 2024.12
+* Latest release: 2025.05
+* Old next release: 2025.Q2 (the project name of release before it was renamed to the "New release" datename)
+* New release: 2025.08 (the release we are working on)
+* Next release: 2025.Q4
+
+* $PROJECTID: The Grml Project ID of the "New Release"
 -->
 
 # Release Kick-Off
 
 - [ ] latest release datename: `20YY.MM-1`
-- [ ] decide: release codename: Link to comment in https://github.com/grml/gsa-doc/issues/8 (*don't leak here 😉)
-- [ ] decide: next release codename: Link to comment in https://github.com/grml/gsa-doc/issues/8 (*dont' leak here 😉)
-- [ ] decide: release datename: `20YY.MM`
+- [ ] decide: "New release" codename: Link to comment in https://github.com/grml/gsa-doc/issues/8 (*Comment: update the issue, but don't leak here 😉*)
+- [ ] decide: "Next release" codename: Link to comment in https://github.com/grml/gsa-doc/issues/8 (*Comment: update the issue, but dont' leak here 😉*)
+- [ ] decide: "New release" datename: `20YY.MM`
 - [ ] decide: testing or unstable as base: `unstable|testing`
 - [ ] decide: pick daily image (from https://gitlab.grml.org/grml/build-daily/-/pipelines)
-- [ ] rename the [GitHub project](https://github.com/orgs/grml/projects/) for the new release to reflect release date (i.e. 2025.Q2 -> 2025.08) and set 
-- [ ] create new release project for the *next* release in https://github.com/orgs/grml/projects using [template](https://github.com/orgs/grml/projects/9) (*placeholder to move the issues which will not be included in the current release*)
+- [ ] rename "New release" project (*Comment: rename the "Old next release" in [GitHub project](https://github.com/orgs/grml/projects/$PROJECTID) to reflect the "New release" date (i.e. 2025.Q2 -> 2025.08*)
 
 # Preflight
 
-- [ ] check repo "grml-live" is empty
+- [ ] create a new project for the "Next release": (*Comment: Use this [template](https://github.com/orgs/grml/projects/9 and link it here as a placeholder to move the issues which will not be included in the new release*)
+- [ ] check repo "grml-live" is empty, otherwise empty "grml-live" (`sudo sudo -u deb-www reprepro -b /var/www/deb.grml.org/repo removematched grml-live '*'`)
 
-* https://deb.grml.org/dists/grml-live/main/binary-amd64/Packages + https://deb.grml.org/dists/grml-live/main/binary-arm64/Packages + https://deb.grml.org/dists/grml-live/main/binary-i386/Packages need to be empty
-* or on `web01`: `sudo sudo -u deb-www reprepro -b /var/www/deb.grml.org/repo list grml-live` returns nothing
-  - [ ] otherwise empty it out (`sudo sudo -u deb-www reprepro -b /var/www/deb.grml.org/repo removematched grml-live '*'`)
+  * https://deb.grml.org/dists/grml-live/main/binary-amd64/Packages + https://deb.grml.org/dists/grml-live/main/binary-arm64/Packages + https://deb.grml.org/dists/grml-live/main/binary-i386/Packages need to be empty
+  * or on `web01`: `sudo sudo -u deb-www reprepro -b /var/www/deb.grml.org/repo list grml-live` returns nothing
 
-- [ ] review [open, ready PRs (without a project set)](https://github.com/search?q=org%3Agrml+type%3Apr+state%3Aopen+draft%3Afalse+no%3Aproject&type=pullrequests) and put into project
-- [ ] review [open Issues (without a project set)](https://github.com/search?q=org%3Agrml+state%3Aopen+no%3Aproject&type=issues&ref=advsearch&s=updated&o=desc) and put into project
-- [ ] check GitHub project for open topics: https://github.com/orgs/grml/projects/$PROJECTID
-- [ ] all git repos and debs are in sync, check https://packages.grml.org
-- [ ] daily image was built with newest packages
+- [ ] review [open, ready PRs (without a project set)](https://github.com/search?q=org%3Agrml+type%3Apr+state%3Aopen+draft%3Afalse+no%3Aproject&type=pullrequests) and put into project "New release" or move to "Next release"
+- [ ] review [open Issues (without a project set)](https://github.com/search?q=org%3Agrml+state%3Aopen+no%3Aproject&type=issues&ref=advsearch&s=updated&o=desc) and put into project "New release" or move to "Next release"
+
+  (*Comment: Do not set the project of the issue, to keep it in the "Backlog"*)
+
+- [ ] check GitHub project for open issues: https://github.com/orgs/grml/projects/$PROJECTID (*Comment: either try to implement/fix them in the "Preflight" phase or move them to the "Next release"*)
+- [ ] all git repos and debs are in sync, check: https://packages.grml.org
+- [ ] daily image was built with newest packages (*Comment: how to check that*)
 - [ ] remove "Old-Latest" release files + update `index.[de|en].html` from `/var/www/ftp-master.grml.org`
-- [ ] prepare build-release job configuration file: [Latest](https://gitlab.grml.org/grml/build-release/-/merge_requests/5)  -- [New 🚀](https://gitlab.grml.org/grml/build-release/-/merge_requests/6) 
-- [ ] prepare website update in new branch and create a PR (i.e. PR for [Grml Release 2025.05](https://github.com/grml/grml.org/pull/102))
+- [ ] prepare build-release job configuration file: (*Comment: i.e: MR for [2025.05 release config](https://gitlab.grml.org/grml/build-release/-/merge_requests/5) + [2025.08 release config](https://gitlab.grml.org/grml/build-release/-/merge_requests/6)*)
+- [ ] prepare website update in new branch and create a PR: (*Comment: i.e. PR for [Grml Release 2025.05](https://github.com/grml/grml.org/pull/102) + [Grml Release 2025.08](https://github.com/grml/grml.org/pull/117)*)
   - [ ] update hugo.yaml with current (pre-)release version
   - [ ] Final: /download/
   - [ ] /faq/ (release name)
   - [ ] /screenshots/ (i.e. PR: [screenshots: Update screenshots for Grml release 2024.12](https://github.com/grml/grml.org/pull/66)
   - [ ] /bugs/known/
   - [ ] changelogs/
-  - [ ] changelogs/README-grml-20XX.MM
+  - [ ] changelogs/README-grml-20YY.MM
   - [ ] front page: add news entry
-- [ ] prepare blog post in branch and create a PR (i.e. PR for [New blogpost: Grml - new stable release 2025.05 available](https://github.com/grml/blog.grml.org/pull/11))
+- [ ] prepare blog post in branch and create a PR: (*Comment: i.e. PR for [New blogpost: Grml - new stable release 2025.05 available](https://github.com/grml/blog.grml.org/pull/11) + [New blogpost: Grml - new stable release 2025.08 available](https://github.com/grml/blog.grml.org/pull/13)*)
 
-# Doing
+# Release Day
 
-https://gitlab.grml.org/grml/build-release/-/pipelines/TBD/builds
+- [ ] trigger [new "Build - Release" pipeline](https://gitlab.grml.org/grml/build-release/-/pipelines/new): (*Comment: Set `USE_CONFIG_FILENAME` to "Next release" datename and link it here. I.e. [release-2025.08 pipeline](https://gitlab.grml.org/grml/build-release/-/pipelines/1126) -> [release-2025.08 pipeline jobs](https://gitlab.grml.org/grml/build-release/-/pipelines/1126/builds)*)
+
+    (*Comment: is it possible to add images to templates?*)
 
 - [ ] marked artifacts of "collect" step in build-release job as Keep
 - [ ] ISO tests
 - [ ] ISO + release update test at $site (@mika knows what is to be done)
 - [ ] copy repos:
-  - [ ] add repos for new release: grml-YYYY.MM grml-live-YYYY.MM and **commented out** grml-YYYY.MM-updates
-  - [ ] add updates repo for old release: (uncomment) grml-YYYY.BB-updates
-  - [ ] repo: copy grml-stable to grml-YYYY.BB-updates repo (`sudo reprepro -b /var/www/deb.grml.org/repo copymatched grml-YYYY.BB-updates grml-stable '*'`
-  - [ ] repo: EMPTY OUT grml-stable ❗❗❗ 
-  - [ ] repo: copy grml-testing to grml-stable
-  - [ ] repo: copy grml-testing to grml-YYYY.MM repo
-  - [ ] 20YY.MM special: mark https://github.com/grml/grml-live/issues/344 as done
-- [ ] build-daily: update config/daily last_release: [MR 🚢 ](https://gitlab.grml.org/grml/build-daily/-/merge_requests/22)
+  - [ ] add repos for "New release": grml-20YY.MM grml-live-20YY.MM and **commented out** grml-20YY.MM-updates
+  - [ ] add updates repo for "Latest release": (uncomment) grml-20YY.MM-updates
+  - [ ] repo: copy grml-stable to grml-20YY.MM-updates repo (`sudo reprepro -b /var/www/deb.grml.org/repo copymatched grml-20YY.MM-updates grml-stable '*'`
+  - [ ] repo: EMPTY OUT grml-stable ❗❗❗ (`sudo reprepro -b /var/www/deb.grml.org/repo removematched grml-stable '*'`)
+  - [ ] repo: copy grml-testing to grml-stable (`sudo reprepro -b /var/www/deb.grml.org/repo copymatched grml-stable grml-testing '*'`)
+  - [ ] repo: copy grml-testing to grml-20YY.MM repo (`sudo reprepro -b /var/www/deb.grml.org/repo copymatched grml-2025.08 grml-testing '*'`)
+- [ ] build-daily: update config/daily `last_release`: (*Comment: i.e. [config: Update last_release for 2025.08](https://gitlab.grml.org/grml/build-daily/-/merge_requests/22)*)
 - [ ] sign + upload to `/var/www/ftp-master.grml.org/` (RC: `devel/`) + to `/var/www/archive.grml.org/htdocs/`:
   - [ ] make sure you have:
-    - [ ] grml*iso
-    - [ ] grml*netboot.tar
-    - [ ] grml*sources.tar
-    - [ ] grml*metadata.tar
+    - [ ] `grml*iso`
+    - [ ] `grml*netboot.tar`
+    - [ ] `grml*sources.tar`
+    - [ ] `grml*metadata.tar`
   - [ ] check sha256 sum files created by build job:
     ```
     sha256sum -c SHA256SUMS-20YY.MM *.sha256
@@ -93,7 +100,7 @@ https://gitlab.grml.org/grml/build-release/-/pipelines/TBD/builds
     ```
     gpg --armor --detach-sign --output SHA256SUMS-20YY.MM.gpg SHA256SUMS-20YY.MM
     ```
-  - [ ] sign ISOs to create *asc:
+  - [ ] sign ISOs to create `*.asc`:
     ```
     for f in *.iso ; gpg --output $f.asc --armor --detach-sig $f
     ```
@@ -102,8 +109,8 @@ https://gitlab.grml.org/grml/build-release/-/pipelines/TBD/builds
     sha256sum -c SHA256SUMS-20YY.MM
     gpg --keyid-format long --verify SHA256SUMS-20YY.MM.gpg SHA256SUMS-20YY.MM
     ```
-  - [ ] upload `grml*iso grml*tar` (best done via curl directly from gitlab)
-  - [ ] upload `SHA256SUMS-20YY.MM.gpg *asc`
+  - [ ] upload `grml*iso grml*tar` (best done via curl directly from gitlab) (*Comment: to where?*)
+  - [ ] upload `SHA256SUMS-20YY.MM.gpg *asc` (*Comment: to where?*)
   - [ ] check on ftp-master.g.o sha256 files and gpg-signatures
     ```
     sha256sum -c SHA256SUMS-20YY.MM *.sha256
@@ -111,14 +118,19 @@ https://gitlab.grml.org/grml/build-release/-/pipelines/TBD/builds
     for x in *iso; do gpg --keyid-format long --verify $x.asc $x; done
     ```
   - [ ] update `index.*html` in ftp-master.g.o
+- [ ] move all remaining items out of project and close it
 
-# Announce
+# Announce Release
 
 - [ ] wait for mirror sync, check https://mirror.grml.org
-- [ ] merge website branch to master: [Previous](https://github.com/grml/grml.org/pull/102) -- [Current PR 🛳](https://github.com/grml/grml.org/pull/TBD)
-- [ ] merge blog branch: [Previous](https://github.com/grml/blog.grml.org/pull/11 ) -- [Current PR 🛳](https://github.com/grml/blog.grml.org/pull/TBD)
-- [ ] mailing list: [Previous](https://lists.mur.at/pipermail/grml-announce/2025-May/000062.html)
-- [ ] mastodon [Previous](https://hachyderm.io/@grmlproject/114511194074491152)
-- [ ] bluesky [Previous](https://bsky.app/profile/grmlproject.bsky.social/post/3lp77x3xla227)
-- [ ] IRC topic
-- [ ] [netboot.xyz: create issue](https://github.com/netbootxyz/netboot.xyz): [Previous issue](https://github.com/netbootxyz/netboot.xyz/issues/1623) [Previous PRs](https://github.com/netbootxyz/debian-squash/pull/3)
+- [ ] merge website update PR to master: (*Comment: i.e. PR for [Grml Release 2025.05](https://github.com/grml/grml.org/pull/102) + [Grml Release 2025.08](https://github.com/grml/grml.org/pull/117)*)
+- [ ] merge blog post PR: (*Comment: i.e. PR for [New blogpost: Grml - new stable release 2025.05 available](https://github.com/grml/blog.grml.org/pull/11) + [New blogpost: Grml - new stable release 2025.08 available](https://github.com/grml/blog.grml.org/pull/13)*)
+- [ ] send to mailing list: (*Comment: i.e. [Grml - new stable release 2025.05 available](https://lists.mur.at/hyperkitty/list/grml-announce@ml.grml.org/thread/2TA7K3B6SVA4VMSGN6TOF2NX5XP2PLPX/) + [Grml - new stable release 2025.08 available](https://lists.mur.at/hyperkitty/list/grml-announce@ml.grml.org/thread/EPGBLAYO2N7EINV7EJUPXT255O3BZBSP/)*)
+- [ ] mastodon: (*Comment: [2025.05](https://hachyderm.io/@grmlproject/114511194074491152) + [2025.08](https://hachyderm.io/@grmlproject/115038916407200568)*)
+- [ ] bluesky: (*Comment: [2025.05](https://bsky.app/profile/grmlproject.bsky.social/post/3lp77x3xla227) + [2025.08](https://bsky.app/profile/grmlproject.bsky.social/post/3lwjlbsn2ks2z)*)
+- [ ] Update IRC topic (*Comment: how?*)
+- [ ] Create [issues @ netboot.xyz](https://github.com/netbootxyz/netboot.xyz/issues/new/choose) + PRs to bump Grml version (*Comment: i.e. [netboot.xyz#1661: Update Grml to 2025.08](https://github.com/netbootxyz/netboot.xyz/issues/1661) + [merged/closed PRs](https://github.com/netbootxyz/debian-squash/pulls?q=is%3Apr+is%3Aclosed+grml)*)
+
+# Post Release Day
+
+- [ ] update [release checklist template](https://github.com/grml/grml/blob/master/.github/ISSUE_TEMPLATE/release-checklist.md) with new learnings

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -8,12 +8,14 @@ assignees: ''
 ---
 
 <!--
+"After the release is before the release": Create a new "release checklist" issue as soon as possible after a Grml release.
+
 Release checklist guide:
 
-* The tasks in the section "Release Kick-Off" needs to be completed on issue creation.
-* Replace YY and MM in the description (with the values from the "New release")
-* Replase $PROJECTID with the GitHub project ID
+* Replace 20YY.MM ("New release" datename) / 20YY.BB (Latest release datename) in the description
+* Replace $PROJECTID with the GitHub project ID of the upcoming release
 * Remove the comments from the tasks (once they are completed)
+* The tasks in section "Preflight" should be completed after the issue has been created.
 * The tasks in section "Preflight" should be completed after the issue has been created.
 * The tasks in section "Release Day" should be completed on release day.
 * The tasks in section "Announce Release" should be completed soon after the release.
@@ -23,26 +25,24 @@ Terminology (with examples):
 
 * Old-Latest release: 2024.12
 * Latest release: 2025.05
-* Old next release: 2025.Q2 (the project name of release before it was renamed to the "New release" datename)
+* Old next release: 2025.Q2 (the project name of the release before it was renamed to the "New release" datename)
 * New release: 2025.08 (the release we are working on)
 * Next release: 2025.Q4
-
-* $PROJECTID: The Grml Project ID of the "New Release"
 -->
 
 # Release Kick-Off
 
-- [ ] latest release datename: `20YY.MM-1`
+- [ ] Latest release datename: `20YY.BB`
 - [ ] decide: "New release" codename: Link to comment in https://github.com/grml/gsa-doc/issues/8 (*Comment: update the issue, but don't leak here 😉*)
 - [ ] decide: "Next release" codename: Link to comment in https://github.com/grml/gsa-doc/issues/8 (*Comment: update the issue, but dont' leak here 😉*)
 - [ ] decide: "New release" datename: `20YY.MM`
+- [ ] decide: Grml Release Meetup date and location
 - [ ] decide: testing or unstable as base: `unstable|testing`
-- [ ] decide: pick daily image (from https://gitlab.grml.org/grml/build-daily/-/pipelines)
-- [ ] rename "New release" project (*Comment: rename the "Old next release" in [GitHub project](https://github.com/orgs/grml/projects/$PROJECTID) to reflect the "New release" date (i.e. 2025.Q2 -> 2025.08*)
+- [ ] rename "New release" project (*Comment: rename the "Old next release" in [GitHub project](https://github.com/orgs/grml/projects/$PROJECTID) to reflect the "New release" date (i.e. 2025.Q2 -> 2025.08) and update $PROJECTID below.*)
+- [ ] create a new project for the "Next release": (*Comment: Make a copy of [template](https://github.com/orgs/grml/projects/9, in Settings change the visibility to "Public" and link it here as a placeholder to move the issues which will not be included in the new release.*)
 
 # Preflight
 
-- [ ] create a new project for the "Next release": (*Comment: Use this [template](https://github.com/orgs/grml/projects/9 and link it here as a placeholder to move the issues which will not be included in the new release*)
 - [ ] check repo "grml-live" is empty, otherwise empty "grml-live" (`sudo sudo -u deb-www reprepro -b /var/www/deb.grml.org/repo removematched grml-live '*'`)
 
   * https://deb.grml.org/dists/grml-live/main/binary-amd64/Packages + https://deb.grml.org/dists/grml-live/main/binary-arm64/Packages + https://deb.grml.org/dists/grml-live/main/binary-i386/Packages need to be empty
@@ -55,8 +55,7 @@ Terminology (with examples):
 
 - [ ] check GitHub project for open issues: https://github.com/orgs/grml/projects/$PROJECTID (*Comment: either try to implement/fix them in the "Preflight" phase or move them to the "Next release"*)
 - [ ] all git repos and debs are in sync, check: https://packages.grml.org
-- [ ] daily image was built with newest packages (*Comment: how to check that*)
-- [ ] remove "Old-Latest" release files + update `index.[de|en].html` from `/var/www/ftp-master.grml.org`
+- [ ] daily image was built with newest packages (*Comment: if we change, add or remove any packages, we have to create a new daily image aka pick a pipeline job*)
 - [ ] prepare build-release job configuration file: (*Comment: i.e: MR for [2025.05 release config](https://gitlab.grml.org/grml/build-release/-/merge_requests/5) + [2025.08 release config](https://gitlab.grml.org/grml/build-release/-/merge_requests/6)*)
 - [ ] prepare website update in new branch and create a PR: (*Comment: i.e. PR for [Grml Release 2025.05](https://github.com/grml/grml.org/pull/102) + [Grml Release 2025.08](https://github.com/grml/grml.org/pull/117)*)
   - [ ] update hugo.yaml with current (pre-)release version
@@ -68,24 +67,28 @@ Terminology (with examples):
   - [ ] changelogs/README-grml-20YY.MM
   - [ ] front page: add news entry
 - [ ] prepare blog post in branch and create a PR: (*Comment: i.e. PR for [New blogpost: Grml - new stable release 2025.05 available](https://github.com/grml/blog.grml.org/pull/11) + [New blogpost: Grml - new stable release 2025.08 available](https://github.com/grml/blog.grml.org/pull/13)*)
+- [ ] review changes ("Changes to Debian package list:") between last daily and the latest release: (*Comment: https://daily.grml.org/grml-full-amd64-testing/ -> `...logs/changes-last-release.txt`*)
+- [ ] download and test daily ISOs
 
 # Release Day
 
-- [ ] trigger [new "Build - Release" pipeline](https://gitlab.grml.org/grml/build-release/-/pipelines/new): (*Comment: Set `USE_CONFIG_FILENAME` to "Next release" datename and link it here. I.e. [release-2025.08 pipeline](https://gitlab.grml.org/grml/build-release/-/pipelines/1126) -> [release-2025.08 pipeline jobs](https://gitlab.grml.org/grml/build-release/-/pipelines/1126/builds)*)
+- [ ] decide: pick daily image (from https://gitlab.grml.org/grml/build-daily/-/pipelines)
+- [ ] trigger [new "Build - Release" pipeline](https://gitlab.grml.org/grml/build-release/-/pipelines/new): (*Comment: Set `USE_CONFIG_FILENAME` to "Next release" datename i.e. `2025.12` and link it here. I.e. [release-2025.08 pipeline](https://gitlab.grml.org/grml/build-release/-/pipelines/1126) -> [release-2025.08 pipeline jobs](https://gitlab.grml.org/grml/build-release/-/pipelines/1126/builds)*)
 
-    (*Comment: is it possible to add images to templates?*)
+<img width="1294" height="759" alt="Image" src="https://github.com/user-attachments/assets/12759109-6da8-43fa-8508-e38cd6b63e64" />
 
-- [ ] marked artifacts of "collect" step in build-release job as Keep
+- [ ] remove "Old-Latest" release files + update `index.[de|en].html` from `/var/www/ftp-master.grml.org`
+- [ ] mark artifacts of "collect" step in build-release job as Keep
 - [ ] ISO tests
 - [ ] ISO + release update test at $site (@mika knows what is to be done)
 - [ ] copy repos:
   - [ ] add repos for "New release": grml-20YY.MM grml-live-20YY.MM and **commented out** grml-20YY.MM-updates
-  - [ ] add updates repo for "Latest release": (uncomment) grml-20YY.MM-updates
+  - [ ] add updates repo for "Latest release": (uncomment) grml-20YY.BB-updates
   - [ ] repo: copy grml-stable to grml-20YY.MM-updates repo (`sudo reprepro -b /var/www/deb.grml.org/repo copymatched grml-20YY.MM-updates grml-stable '*'`
   - [ ] repo: EMPTY OUT grml-stable ❗❗❗ (`sudo reprepro -b /var/www/deb.grml.org/repo removematched grml-stable '*'`)
   - [ ] repo: copy grml-testing to grml-stable (`sudo reprepro -b /var/www/deb.grml.org/repo copymatched grml-stable grml-testing '*'`)
-  - [ ] repo: copy grml-testing to grml-20YY.MM repo (`sudo reprepro -b /var/www/deb.grml.org/repo copymatched grml-2025.08 grml-testing '*'`)
-- [ ] build-daily: update config/daily `last_release`: (*Comment: i.e. [config: Update last_release for 2025.08](https://gitlab.grml.org/grml/build-daily/-/merge_requests/22)*)
+  - [ ] repo: copy grml-testing to grml-20YY.MM repo (`sudo reprepro -b /var/www/deb.grml.org/repo copymatched grml-2025.MM grml-testing '*'`)
+- [ ] build-daily: update config/daily `last_release` to to `20YY.MM` https://gitlab.grml.org/grml/build-daily/-/blob/main/config/daily and create a MR (*Comment: i.e. [config: Update last_release for 2025.08](https://gitlab.grml.org/grml/build-daily/-/merge_requests/22)*)
 - [ ] sign + upload to `/var/www/ftp-master.grml.org/` (RC: `devel/`) + to `/var/www/archive.grml.org/htdocs/`:
   - [ ] make sure you have:
     - [ ] `grml*iso`
@@ -109,8 +112,15 @@ Terminology (with examples):
     sha256sum -c SHA256SUMS-20YY.MM
     gpg --keyid-format long --verify SHA256SUMS-20YY.MM.gpg SHA256SUMS-20YY.MM
     ```
-  - [ ] upload `grml*iso grml*tar` (best done via curl directly from gitlab) (*Comment: to where?*)
+  - [ ] upload `grml*iso grml*tar` (best done via curl directly from gitlab)
+
+    * On `web01` download `artifacts.zip`: `curl --location --header "PRIVATE-TOKEN: glpat-XXXX" "https://gitlab.grml.org/api/v4/projects/grml%2Fbuild-release/jobs/7592/artifacts" -O`
+    * Unzip `artifacts.zip` and move the files `grml*iso grml*tar` to `/var/www/ftp-master.grml.org/`
+
   - [ ] upload `SHA256SUMS-20YY.MM.gpg *asc` (*Comment: to where?*)
+
+    * From the unzipped `artifacts.zip` move the files `SHA256SUMS-20YY.MM.gpg *asc` to `/var/www/ftp-master.grml.org/`
+
   - [ ] check on ftp-master.g.o sha256 files and gpg-signatures
     ```
     sha256sum -c SHA256SUMS-20YY.MM *.sha256
@@ -134,3 +144,4 @@ Terminology (with examples):
 # Post Release Day
 
 - [ ] update [release checklist template](https://github.com/grml/grml/blob/master/.github/ISSUE_TEMPLATE/release-checklist.md) with new learnings
+- [ ] "After the release is before the release": Create a new "release checklist" issue as soon as possible after a Grml release


### PR DESCRIPTION
Updated release checklist template with new learnings from Grml release 2025.08, see: https://github.com/grml/grml/issues/243#issuecomment-3193746356

Updated + added some tasks from the last release checklist and added some comments on what to do.

Improved the "hidden" "release checklist guide" to make it clearer what to do and when.

Added the term "Old next release": the project name before it was renamed to the "New release" datename.

Changed the section name "Doing" to "Release Day".
I think this fits better and also added a new section "Post Release Day" for non-urgent tasks after the release.

TBH, the "Release Day" section is a bit unclear for me, but I think this can be improved after the next release.
 
TODOs (before merging -> created this PR as draft): Some comments are questions. It is not clear to me how to complete theses tasks. The comment should be improved before merging or keep it to be improved after the next release.